### PR TITLE
Remove totallyTyped in favour of errorLevel=1

### DIFF
--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -4,7 +4,7 @@ Feature: MockReturn
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/PHPUnitIntegration.feature
+++ b/tests/acceptance/PHPUnitIntegration.feature
@@ -4,7 +4,7 @@ Feature: PHPUnitIntegration
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>


### PR DESCRIPTION
`totallyTyped` was deprecated in Psalm 4 and removed in Psalm 5
